### PR TITLE
fix: extract language from attrs['class'] instead of props['class']

### DIFF
--- a/packages/vue-markdown/src/index.ts
+++ b/packages/vue-markdown/src/index.ts
@@ -279,7 +279,7 @@ const vueMarkdownImpl = defineComponent({
         /** all element name and custom aliases */
         const aliasList: AliasList = []
 
-        let attrs = {}
+        let attrs: Record<string, any> = {}
         const props: Record<string, any> = {}
         const thisContext = { ...context }
 
@@ -312,8 +312,8 @@ const vueMarkdownImpl = defineComponent({
                 break
               // TODO: maybe use <pre> instead for customizing from <pre> not <code> ?
               case 'code':
-                props.languageOriginal = Array.isArray(props['class'])
-                  ? props['class'].find(cls => cls.startsWith('language-'))
+                props.languageOriginal = Array.isArray(attrs['class'])
+                  ? attrs['class'].find(cls => cls.startsWith('language-'))
                   : ''
                 props.language = props.languageOriginal ? props.languageOriginal.replace('language-', '') : ''
                 props.inline = 'tagName' in parent && parent.tagName !== 'pre'


### PR DESCRIPTION
Currently, the `language` and `languageOriginal` arguments passed to the scoped slot of `code, inline-code, block-code` are always empty strings. This PR attempts to fix this problem.