### PR TITLE
docs(readme): add network dependents badge

### DIFF
--- a/.github/workflows/dependents.yml
+++ b/.github/workflows/dependents.yml
@@ -1,0 +1,16 @@
+name: Dependents Action
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 0 1 * *"
+  workflow_dispatch:
+
+jobs:
+  dependents:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: gouravkhunger/dependents.info@main

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # @crazydos/vue-markdown
 [![npm version](https://img.shields.io/npm/v/@crazydos/vue-markdown.svg)](https://www.npmjs.com/package/@crazydos/vue-markdown)
 [![npm downloads](https://img.shields.io/npm/dm/@crazydos/vue-markdown.svg)](https://www.npmjs.com/package/@crazydos/vue-markdown)
+[![network dependents](https://dependents.info/shunnNet/vue-markdown/badge)](https://dependents.info/shunnNet/vue-markdown)
 [![License](https://img.shields.io/github/license/nuxt/nuxt.svg)](https://github.com/shunnNet/vue-markdown/blob/main/LICENSE)
 
 This is a package that provide Vue 3+ component to render markdown content with [`unified`](https://github.com/unifiedjs/unified) pipeline.


### PR DESCRIPTION
Hi there!

Thank you for this awesome project! This PR adds a network dependents badge in the `README.md` file to showcase its impact.

I've created this using an [open source](https://github.com/gouravkhunger/dependents.info) tool I built myself: [dependents.info](https://dependents.info). Here's a preview of how the image renders:

## Used by

![github network dependents image generated by dependents.info](https://dependents.info/gouravkhunger/jekyll-auto-authors/image.svg)

There's also a shield.io based badge if you prefer the smaller variant.

![github network dependents total count generated by dependents.info](https://dependents.info/gouravkhunger/jekyll-auto-authors/badge)

This is how it will look for your repo

<img width="746" alt="image" src="https://github.com/user-attachments/assets/05809a5c-c8e1-429f-8e4a-45c159c400c1" />

Since the users count is still growing - i haven't included the full image. if you wish to you can add it anytime in the future.

Please feel free to close the PR if you don't want to have this!