### PR TITLE
fix:correct export types

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ import rehypeShiki from '@shikijs/rehype'
   <Suspense>
     <VueMarkdownAsync
       :markdown="markdown"
-      :rehype-plugins="[rehypeShiki]"
+      :rehype-plugins="[rehypeShiki, { theme: 'github-light' }]"
     />
   </Suspense>
 </template>
@@ -429,7 +429,7 @@ Here's an example configuration that prevents the rendering of all HTML tags, di
 
 ```vue
 <script setup lang="ts">
-import VueMarkdown, { SanitizeOptions } from '@crazydos/vue-markdown'
+import { type SanitizeOptions, VueMarkdown } from '@crazydos/vue-markdown'
 import { ref } from 'vue'
 
 const sanitizeOption: SanitizeOptions = {

--- a/packages/vue-markdown/src/hast-to-vnode.ts
+++ b/packages/vue-markdown/src/hast-to-vnode.ts
@@ -185,6 +185,7 @@ export function getVNodeInfos(
  * TODO:
  * @param node - hast node
  * @param aliasList - html tag list. The earlier alias has higher priority. ?
+ * @param vnodeProps - vnode props
  * @param attrs - attrs
  * @param customAttrs - custom attrs object
  * @returns attrs

--- a/packages/vue-markdown/src/index.ts
+++ b/packages/vue-markdown/src/index.ts
@@ -1,4 +1,5 @@
 export { VueMarkdown, VueMarkdownAsync } from './components'
 export { getVNodeInfos, render, renderChildren } from './hast-to-vnode'
-export type { CustomAttrs, TVueMarkdown, TVueMarkdownProps } from './types'
+export type { CustomAttrs, SanitizeOptions, TVueMarkdown, TVueMarkdownProps } from './types'
 export { createProcessor, useMarkdownProcessor } from './useProcessor'
+export type { PluggableList } from 'unified'


### PR DESCRIPTION
doc: fix the `rehypeShiki `  useage in `README.md`
doc: fix the `SanitizeOptions` export in `README.md`
types:correct  export type `SanitizeOptions` 
types: export type `PluggableList ` from `unified`

fixed : #14 